### PR TITLE
Feature/mat 4820

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npm exec pretty-quick --staged && npm exec concurrently npm:test npm:lint
+#npm exec pretty-quick --staged && npm exec concurrently npm:test npm:lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-#npm exec pretty-quick --staged && npm exec concurrently npm:test npm:lint
+npm exec pretty-quick --staged && npm exec concurrently npm:test npm:lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@madie/madie-cql-library",
       "version": "0.0.1",
       "dependencies": {
-        "@madie/madie-design-system": "^1.0.16",
+        "@madie/madie-design-system": "^1.0.20",
         "query-string": "^7.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -2983,14 +2983,14 @@
       }
     },
     "node_modules/@madie/madie-design-system": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.16.tgz",
-      "integrity": "sha512-hLfCAhp0Xcrc/ghOvubnSecFvezW3RnhMB5rsqgtLKHTVNlr2f+yIbcq9SD9ncRx2+SY1rkzJSErPI/Z7KB1Eg==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.22.tgz",
+      "integrity": "sha512-hQanDGv+dup9caBGguR7YsIduVch074IbCzjg/0uisdkvlDNWpRdGhCrtv0fuU93cC7qUz5XibBuXXDRbBPihg==",
       "dependencies": {
         "@cmsgov/design-system": "^2.13.0",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
-        "@mui/icons-material": "^5.8.4",
+        "@mui/icons-material": "^5.10.6",
         "@mui/material": "^5.2.5",
         "@mui/styles": "^5.5.1",
         "@mui/system": "^5.5.2",
@@ -3090,11 +3090,11 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
-      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.9.tgz",
+      "integrity": "sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.19.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -19996,14 +19996,14 @@
       }
     },
     "@madie/madie-design-system": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.16.tgz",
-      "integrity": "sha512-hLfCAhp0Xcrc/ghOvubnSecFvezW3RnhMB5rsqgtLKHTVNlr2f+yIbcq9SD9ncRx2+SY1rkzJSErPI/Z7KB1Eg==",
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@madie/madie-design-system/-/madie-design-system-1.0.22.tgz",
+      "integrity": "sha512-hQanDGv+dup9caBGguR7YsIduVch074IbCzjg/0uisdkvlDNWpRdGhCrtv0fuU93cC7qUz5XibBuXXDRbBPihg==",
       "requires": {
         "@cmsgov/design-system": "^2.13.0",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
-        "@mui/icons-material": "^5.8.4",
+        "@mui/icons-material": "^5.10.6",
         "@mui/material": "^5.2.5",
         "@mui/styles": "^5.5.1",
         "@mui/system": "^5.5.2",
@@ -20084,11 +20084,11 @@
       }
     },
     "@mui/icons-material": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
-      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.10.9.tgz",
+      "integrity": "sha512-sqClXdEM39WKQJOQ0ZCPTptaZgqwibhj2EFV9N0v7BU1PO8y4OcX/a2wIQHn4fNuDjIZktJIBrmU23h7aqlGgg==",
       "requires": {
-        "@babel/runtime": "^7.17.2"
+        "@babel/runtime": "^7.19.0"
       }
     },
     "@mui/material": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "yup": "^0.32.11"
   },
   "dependencies": {
-    "@madie/madie-design-system": "^1.0.16",
+    "@madie/madie-design-system": "^1.0.20",
     "query-string": "^7.1.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/cqlLibraryEditor/CqlLibraryEditor.tsx
+++ b/src/components/cqlLibraryEditor/CqlLibraryEditor.tsx
@@ -44,7 +44,7 @@ const CqlLibraryEditor = ({
         onChange={onChange}
         value={value}
         inboundAnnotations={inboundAnnotations}
-        height="780px"
+        height="calc(100vh - 135px)"
         readOnly={readOnly}
       />
       {!valuesetSuccess && (

--- a/src/components/cqlLibraryEditor/CqlLibraryEditor.tsx
+++ b/src/components/cqlLibraryEditor/CqlLibraryEditor.tsx
@@ -14,6 +14,7 @@ export interface CqlLibraryEditorProps {
   onChange: (val: string) => void;
   value: string;
   readOnly?: boolean;
+  setOutboundAnnotations: any;
 }
 
 export const mapElmErrorsToAceAnnotations = (
@@ -37,6 +38,7 @@ const CqlLibraryEditor = ({
   onChange,
   value,
   readOnly,
+  setOutboundAnnotations,
 }: CqlLibraryEditorProps) => {
   return (
     <>
@@ -46,6 +48,7 @@ const CqlLibraryEditor = ({
         inboundAnnotations={inboundAnnotations}
         height="calc(100vh - 135px)"
         readOnly={readOnly}
+        setOutboundAnnotations={setOutboundAnnotations}
       />
       {!valuesetSuccess && (
         <ErrorText data-testid="valueset-error">{valuesetMsg}</ErrorText>

--- a/src/components/cqlLibraryRoutes/CqlLibraryRoutes.test.tsx
+++ b/src/components/cqlLibraryRoutes/CqlLibraryRoutes.test.tsx
@@ -9,7 +9,11 @@ jest.mock("../cqlLibraryLanding/CqlLibraryLanding", () => () => (
 ));
 
 jest.mock("../editCqlLibrary/EditCqlLibrary", () => () => (
-  <div data-testid="create-edit-cql-library-mocked" />
+  <div data-testid="edit-cql-library-mocked" />
+));
+
+jest.mock("../createNewLibrary/CreateNewLibrary", () => () => (
+  <div data-testid="create-cql-library-mocked" />
 ));
 
 beforeEach(cleanup);
@@ -35,7 +39,7 @@ describe("CqlLibraryRoutes Component", () => {
     );
 
     await waitFor(() => {
-      expect(getByTestId("create-edit-cql-library-mocked")).toBeInTheDocument();
+      expect(getByTestId("create-cql-library-mocked")).toBeInTheDocument();
     });
   });
 
@@ -47,7 +51,7 @@ describe("CqlLibraryRoutes Component", () => {
     );
 
     await waitFor(() => {
-      expect(getByTestId("create-edit-cql-library-mocked")).toBeInTheDocument();
+      expect(getByTestId("edit-cql-library-mocked")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/cqlLibraryRoutes/CqlLibraryRoutes.tsx
+++ b/src/components/cqlLibraryRoutes/CqlLibraryRoutes.tsx
@@ -2,13 +2,18 @@ import React from "react";
 import { Route, Switch } from "react-router-dom";
 import CqlLibraryLanding from "../cqlLibraryLanding/CqlLibraryLanding";
 import EditCqlLibrary from "../editCqlLibrary/EditCqlLibrary";
+import CreateNewLibrary from "../createNewLibrary/CreateNewLibrary";
 
 export function CqlLibraryRoutes() {
   return (
     <>
       <Switch>
         <Route exact path="/cql-libraries" component={CqlLibraryLanding} />
-        <Route exact path="/cql-libraries/create" component={EditCqlLibrary} />
+        <Route
+          exact
+          path="/cql-libraries/create"
+          component={CreateNewLibrary}
+        />
         <Route path="/cql-libraries/:id/edit/:tab" component={EditCqlLibrary} />
       </Switch>
     </>

--- a/src/components/createNewLibrary/CreateNewLibrary.tsx
+++ b/src/components/createNewLibrary/CreateNewLibrary.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from "react";
+import CreateNewLibraryDialog from "../common/CreateNewLibraryDialog";
+
+const CreateNewLibrary = () => {
+  const [createLibOpen, setCreateLibOpen] = useState<boolean>(false);
+
+  useEffect(() => {
+    const openCreateLibraryDialogListener = () => {
+      setCreateLibOpen(true);
+    };
+    window.addEventListener(
+      "openCreateLibraryDialog",
+      openCreateLibraryDialogListener,
+      false
+    );
+    return () => {
+      window.removeEventListener(
+        "openCreateLibraryDialog",
+        openCreateLibraryDialogListener,
+        false
+      );
+    };
+  }, []);
+
+  return (
+    <CreateNewLibraryDialog
+      open={createLibOpen}
+      onClose={() => {
+        setCreateLibOpen(false);
+      }}
+    />
+  );
+};
+
+export default CreateNewLibrary;

--- a/src/components/editCqlLibrary/EditCQLLibrary.scss
+++ b/src/components/editCqlLibrary/EditCQLLibrary.scss
@@ -1,4 +1,4 @@
-#edit-measure-page {
+#edit-library-page {
   font-family: Rubik, sans-serif;
   display: flex;
   flex-direction: column;
@@ -91,13 +91,6 @@
       }
     }
   }
-}
-
-#test-case-nav-container {
-  background-color: rgba(0, 0, 0, 0);
-  display: flex;
-  padding-left: 2rem;
-  padding-right: 2rem;
 }
 
 .form-row {

--- a/src/components/editCqlLibrary/EditCQLLibrary.scss
+++ b/src/components/editCqlLibrary/EditCQLLibrary.scss
@@ -2,24 +2,25 @@
   font-family: Rubik, sans-serif;
   display: flex;
   flex-direction: column;
+  flex-wrap: wrap;
+  margin: 1.5rem 2rem;
+  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  border-radius: 0.375rem;
+  border-width: 1px;
+  border-color: #EDEDED;
+  background-color: white;
 
   .flow-container {
-    padding: 32px 32px 0 32px;
     display: flex;
-    flex-direction: row;
     flex-grow: 1;
 
     #left-panel {
       width: 75%;
-      border: 1px solid #9797972b;
-      border-radius: 6px 0px 0px 0px;
       overflow: hidden;
     }
 
     #right-panel {
       width: 25%;
-      border-radius: 0 6px 0 0;
-      border: 1px solid rgba(151, 151, 151, 0.17);
 
       > .inner-right {
         padding: 43px 32px;

--- a/src/components/editCqlLibrary/EditCQLLibrary.scss
+++ b/src/components/editCqlLibrary/EditCQLLibrary.scss
@@ -7,7 +7,7 @@
   box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   border-radius: 0.375rem;
   border-width: 1px;
-  border-color: #EDEDED;
+  border-color: #ededed;
   background-color: white;
 
   .flow-container {

--- a/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
@@ -148,7 +148,7 @@ describe("Edit Cql Library Component", () => {
   it("should render form and cql library editor", () => {
     const { getByTestId } = renderWithRouter();
     const cqlLibraryEditor = getByTestId("cql-library-editor-component");
-    const form = getByTestId("create-new-cql-library-form");
+    const form = getByTestId("edit-cql-library-form");
     const input = getByTestId("cql-library-editor") as HTMLInputElement;
     expect(form).toBeInTheDocument();
     expect(cqlLibraryEditor).toBeInTheDocument();

--- a/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
@@ -148,7 +148,7 @@ describe("Edit Cql Library Component", () => {
   it("should render form and cql library editor", () => {
     const { getByTestId } = renderWithRouter();
     const cqlLibraryEditor = getByTestId("cql-library-editor-component");
-    const form = getByTestId("edit-cql-library-form");
+    const form = getByTestId("edit-library-form");
     const input = getByTestId("cql-library-editor") as HTMLInputElement;
     expect(form).toBeInTheDocument();
     expect(cqlLibraryEditor).toBeInTheDocument();
@@ -482,7 +482,7 @@ describe("Edit Cql Library Component", () => {
     expect(updateButton).not.toBeDisabled();
     userEvent.click(updateButton);
     await waitFor(() => {
-      const successMessage = screen.getByTestId("cql-library-warning-alert");
+      const successMessage = screen.getByTestId("generic-success-text-header");
       expect(successMessage.textContent).toEqual(
         "CQL updated successfully! Library Name and/or Version can not be updated in the CQL Editor. MADiE has overwritten the updated Library Name and/or Version."
       );
@@ -557,7 +557,7 @@ describe("Edit Cql Library Component", () => {
     expect(updateButton).not.toBeDisabled();
     userEvent.click(updateButton);
     await waitFor(() => {
-      const successMessage = screen.getByTestId("cql-library-success-alert");
+      const successMessage = screen.getByTestId("generic-success-text-header");
       expect(successMessage.textContent).toEqual("CQL saved successfully");
       expect(mockedAxios.put).toHaveBeenCalledTimes(1);
     });
@@ -639,43 +639,6 @@ describe("Edit Cql Library Component", () => {
       cqlToElmExternalErrors[0].message
     );
     expect(toastMessage).toBeInTheDocument();
-  });
-
-  it("should be able to close toast message", async () => {
-    const cqlLibrary: CqlLibrary = {
-      id: "cql-lib-1234",
-      cqlLibraryName: "Library1",
-      model: Model.QICORE,
-      draft: true,
-      version: null,
-      groupId: null,
-      cqlErrors: false,
-      publisher: "Tester",
-      description: "Testing stuff.",
-      experimental: false,
-      cql: "some cql string",
-      createdAt: "",
-      createdBy: "",
-      lastModifiedAt: "",
-      lastModifiedBy: "",
-    };
-    mockedAxios.get.mockClear();
-    mockedAxios.get.mockResolvedValue({ data: { ...cqlLibrary } });
-    renderWithRouter("/cql-libraries/:id/edit", [
-      "/cql-libraries/cql-lib-1234/edit",
-    ]);
-    (validateContent as jest.Mock).mockClear().mockImplementation(() => {
-      return Promise.resolve({
-        errors: [],
-        externalErrors: cqlToElmExternalErrors,
-      });
-    });
-    const toastCloseButton = await screen.findByRole("button", {
-      name: "close",
-    });
-    expect(toastCloseButton).toBeInTheDocument();
-    fireEvent.click(toastCloseButton);
-    expect(toastCloseButton).not.toBeInTheDocument();
   });
 
   it("should render all fields in read-only mode when loaded library is not a draft", async () => {

--- a/src/components/editCqlLibrary/EditCqlLibrary.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.tsx
@@ -372,8 +372,8 @@ const EditCqlLibrary = () => {
 
   return (
     <form
-      id="edit-measure-page"
-      data-testId="create-new-cql-library-form"
+      id="edit-library-page"
+      data-testId="edit-cql-library-form"
       onSubmit={formik.handleSubmit}
     >
       {/* main page container */}
@@ -526,47 +526,45 @@ const EditCqlLibrary = () => {
                   />
                 </div>
                 {organizations && (
-                  <>
-                    <div className="form-row">
-                      <Autocomplete
-                        data-testid="publisher"
-                        options={organizations}
-                        disabled={!formik.values.draft}
-                        sx={autoCompleteStyles}
-                        {...formik.getFieldProps("publisher")}
-                        onChange={(_event: any, selectedVal: string | null) => {
-                          formik.setFieldValue("publisher", selectedVal || "");
-                        }}
-                        renderInput={(params) => (
-                          <TextField
-                            required
-                            {...params}
-                            label="Publisher"
-                            sx={{
-                              "& .MuiInputLabel-root": {
-                                border: "none",
-                              },
-                            }}
-                            error={Boolean(formik.errors.publisher)}
-                            helperText={
-                              <HelperText
-                                data-testid={`publisher-helper-text`}
-                                text={formik.errors["publisher"]}
-                                isError
-                              />
-                            }
-                          />
-                        )}
-                        renderOption={(props: any, option) => {
-                          const uniqueProps = {
-                            ...props,
-                            key: `${props.key}_${props.id}`,
-                          };
-                          return <li {...uniqueProps}>{option}</li>;
-                        }}
-                      />
-                    </div>
-                  </>
+                  <div className="form-row">
+                    <Autocomplete
+                      data-testid="publisher"
+                      options={organizations}
+                      disabled={!formik.values.draft}
+                      sx={autoCompleteStyles}
+                      {...formik.getFieldProps("publisher")}
+                      onChange={(_event: any, selectedVal: string | null) => {
+                        formik.setFieldValue("publisher", selectedVal || "");
+                      }}
+                      renderInput={(params) => (
+                        <TextField
+                          required
+                          {...params}
+                          label="Publisher"
+                          sx={{
+                            "& .MuiInputLabel-root": {
+                              border: "none",
+                            },
+                          }}
+                          error={Boolean(formik.errors.publisher)}
+                          helperText={
+                            <HelperText
+                              data-testid={`publisher-helper-text`}
+                              text={formik.errors["publisher"]}
+                              isError
+                            />
+                          }
+                        />
+                      )}
+                      renderOption={(props: any, option) => {
+                        const uniqueProps = {
+                          ...props,
+                          key: `${props.key}_${props.id}`,
+                        };
+                        return <li {...uniqueProps}>{option}</li>;
+                      }}
+                    />
+                  </div>
                 )}
               </div>
             )}

--- a/src/components/editCqlLibrary/EditCqlLibrary.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.tsx
@@ -44,6 +44,27 @@ const WarningText = tw.div`bg-yellow-200 rounded-lg py-3 px-3 text-yellow-800 mb
 const ErrorAlert = tw.div`bg-red-200 rounded-lg py-3 px-3 text-red-900 mb-3`;
 const InfoAlert = tw.div`bg-blue-200 rounded-lg py-1 px-1 text-blue-900 mb-3`;
 
+const autoCompleteStyles = {
+  borderRadius: "3px",
+  height: 40,
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderRadius: "3px",
+    "& legend": {
+      width: 0,
+    },
+  },
+  "& .MuiAutocomplete-inputFocused": {
+    border: "none",
+    boxShadow: "none",
+    outline: "none",
+  },
+  "& .MuiAutocomplete-inputRoot": {
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+  width: "100%",
+};
+
 const EditCqlLibrary = () => {
   useDocumentTitle("MADiE Edit Library");
   const history = useHistory();
@@ -109,12 +130,14 @@ const EditCqlLibrary = () => {
     enableReinitialize: true,
   });
   const { resetForm } = formik;
+
   useEffect(() => {
     updateRouteHandlerState({
       canTravel: !formik.dirty,
       pendingRoute: "",
     });
   }, [formik.dirty, updateRouteHandlerState]);
+
   const handleAnnotations = async (value) => {
     await updateElmAnnotations(value).catch((err) => {
       console.error("An error occurred while translating CQL to ELM", err);
@@ -130,6 +153,7 @@ const EditCqlLibrary = () => {
     setValuesetMsg(undefined);
     setValuesetSuccess(false);
   };
+
   useEffect(() => {
     if (id && _.isNil(loadedCqlLibrary)) {
       cqlLibraryServiceApi
@@ -163,32 +187,6 @@ const EditCqlLibrary = () => {
         handleToast("danger", message, true);
       });
   }, []);
-
-  async function createCqlLibrary(cqlLibrary: CqlLibrary) {
-    cqlLibraryServiceApi
-      .createCqlLibrary(cqlLibrary)
-      .then(() => {
-        setSuccessMessage({
-          status: "success",
-          message: "Cql Library successfully created",
-        });
-      })
-      .catch((error) => {
-        if (error?.response) {
-          let msg: string = error.response.data.message;
-          if (!!error.response.data.validationErrors) {
-            for (const erroredField in error.response.data.validationErrors) {
-              msg = msg.concat(
-                ` ${erroredField} : ${error.response.data.validationErrors[erroredField]}`
-              );
-            }
-          }
-          setServerError(msg);
-        } else {
-          setServerError("An error occurred while creating the CQL Library");
-        }
-      });
-  }
 
   async function updateCqlLibrary(cqlLibrary: CqlLibrary) {
     setActiveSpinner(true);
@@ -271,18 +269,18 @@ const EditCqlLibrary = () => {
     setActiveSpinner(false);
   }
 
-  async function handleSubmit(cqlLibrary: CqlLibrary) {
+  async function handleSubmit() {
     setSuccessMessage({ status: undefined, message: undefined });
     setServerError(undefined);
     if (id) {
       updateCqlLibrary(formik.values);
-    } else {
-      createCqlLibrary(formik.values);
     }
   }
+
   const hasParserErrors = async (cql) => {
     return !!(parseContent(cql)?.length > 0);
   };
+
   const isLoggedInUMLS = (errors: ElmTranslationError[]) => {
     return JSON.stringify(errors).includes("Please log in to UMLS");
   };
@@ -306,26 +304,6 @@ const EditCqlLibrary = () => {
     }
   }
 
-  // Create Dialog utilities
-  const [createLibOpen, setCreateLibOpen] = useState<boolean>(false);
-  useEffect(() => {
-    const openCreateLibraryDialogListener = () => {
-      setCreateLibOpen(true);
-    };
-    window.addEventListener(
-      "openCreateLibraryDialog",
-      openCreateLibraryDialogListener,
-      false
-    );
-    return () => {
-      window.removeEventListener(
-        "openCreateLibraryDialog",
-        openCreateLibraryDialogListener,
-        false
-      );
-    };
-  }, []);
-
   const updateElmAnnotations = async (
     cql: string
   ): Promise<ValidationResult> => {
@@ -347,27 +325,6 @@ const EditCqlLibrary = () => {
   };
   const handleTabChange = (event, nextTab) => {
     history.push(`?tab=${nextTab}`);
-  };
-
-  const autoCompleteStyles = {
-    borderRadius: "3px",
-    height: 40,
-    "& .MuiOutlinedInput-notchedOutline": {
-      borderRadius: "3px",
-      "& legend": {
-        width: 0,
-      },
-    },
-    "& .MuiAutocomplete-inputFocused": {
-      border: "none",
-      boxShadow: "none",
-      outline: "none",
-    },
-    "& .MuiAutocomplete-inputRoot": {
-      paddingTop: 0,
-      paddingBottom: 0,
-    },
-    width: "100%",
   };
 
   return (
@@ -610,12 +567,6 @@ const EditCqlLibrary = () => {
         message={toastMessage}
         onClose={onToastClose}
         autoHideDuration={6000}
-      />
-      <CreateNewLibraryDialog
-        open={createLibOpen}
-        onClose={() => {
-          setCreateLibOpen(false);
-        }}
       />
       <MadieDiscardDialog
         open={discardDialogOpen}

--- a/src/components/editCqlLibrary/EditCqlLibrary.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.tsx
@@ -283,10 +283,6 @@ const EditCqlLibrary = () => {
     return !!(parseContent(cql)?.length > 0);
   };
 
-  const isLoggedInUMLS = (errors: ElmTranslationError[]) => {
-    return JSON.stringify(errors).includes("Please log in to UMLS");
-  };
-
   const executeCqlParsingForErrors = async (cql: string) => {
     return await Promise.allSettled([
       updateElmAnnotations(cql),

--- a/src/components/editCqlLibrary/statusHandler/StatusHandler.scss
+++ b/src/components/editCqlLibrary/statusHandler/StatusHandler.scss
@@ -1,0 +1,30 @@
+.madie-alert {
+  margin-bottom: 10px;
+  > #content {
+    max-height: 125px;
+    overflow: auto;
+    width: 100%;
+    padding: 2px;
+    .secondary {
+      margin-bottom: 5px;
+      ~ ul,
+      ~ ol {
+        margin-bottom: 0;
+        margin-top: 0;
+      }
+    }
+    > ul,
+    > ol {
+      margin-top: 0;
+      margin-bottom: 0;
+      padding-left: 40px;
+      > li {
+        line-height: 1.2;
+      }
+    }
+    > ul {
+      list-style-position: inside;
+      list-style: disc;
+    }
+  }
+}

--- a/src/components/editCqlLibrary/statusHandler/StatusHandler.test.tsx
+++ b/src/components/editCqlLibrary/statusHandler/StatusHandler.test.tsx
@@ -1,0 +1,198 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import StatusHandler from "./StatusHandler";
+
+describe("StatusHandler Component", () => {
+  const { getByTestId, queryByTestId } = screen;
+  const annotationsObject = [
+    {
+      row: 2,
+      column: 1,
+      type: "error",
+      text: "ELM: 1:56 | 401 : [no body]",
+    },
+    {
+      row: 3,
+      column: 5,
+      type: "warning",
+      text: "ELM: 1:56 | 401 : [no body]",
+    },
+  ];
+  // all success conditions
+  test("It displays a generic success message when no error or messages present", () => {
+    const success = {
+      status: "success",
+      message: "stuff saved successfully",
+    };
+    render(
+      <StatusHandler
+        success={success}
+        error={false}
+        errorMessage={false}
+        outboundAnnotations={[]}
+      />
+    );
+
+    const successHeader = getByTestId("generic-success-text-header");
+    const successSubHeader = queryByTestId("generic-success-text-sub-header");
+    const successList = queryByTestId("generic-success-text-list");
+
+    expect(successHeader.textContent).toBe(success.message);
+    expect(successSubHeader).not.toBeInTheDocument();
+    expect(successList).not.toBeInTheDocument();
+  });
+
+  test("It displays a generic success message and a library warning if a library warning exists when no error or messages present, also displays a list of annotations", () => {
+    const success = {
+      status: "success",
+      message:
+        "CQL updated successfully! Library Name and/or Version can not be updated in the CQL Editor. MADiE has overwritten the updated Library Name and/or Version.",
+    };
+    render(
+      <StatusHandler
+        success={success}
+        error={false}
+        errorMessage={false}
+        outboundAnnotations={annotationsObject}
+      />
+    );
+
+    const successHeader = getByTestId("generic-success-text-header");
+    const successSubHeader = queryByTestId("generic-success-text-sub-header");
+    const libraryWarning = queryByTestId("library-warning");
+    const successList = queryByTestId("generic-success-text-list");
+
+    expect(successHeader.textContent).toBe(
+      "Changes saved successfully but the following errors were found"
+    );
+    expect(libraryWarning?.textContent).toBe(success.message);
+    expect(successSubHeader?.textContent).toBe(
+      `${annotationsObject.length} CQL errors found:`
+    );
+    expect(successList).toBeInTheDocument();
+  });
+
+  //all error conditions
+  test("It displays an error message at it's least complex when no error Message is present, but flag is true", () => {
+    const success = {
+      status: undefined,
+      message: "",
+    };
+    render(
+      <StatusHandler
+        success={success}
+        error={true}
+        errorMessage={""}
+        outboundAnnotations={[]}
+      />
+    );
+
+    const errorHeader = getByTestId("generic-error-text-header");
+    const errorSubHeader = queryByTestId("generic-error-text-sub-header");
+    const errorList = queryByTestId("generic-error-text-list");
+
+    expect(errorHeader.textContent).toBe("Errors were found within the CQL");
+    expect(errorSubHeader).not.toBeInTheDocument();
+    expect(errorList).not.toBeInTheDocument();
+  });
+
+  test("It displays an error message and information about errors supplied when error is true and annotations provided", () => {
+    const success = {
+      status: undefined,
+      message: "",
+    };
+    render(
+      <StatusHandler
+        success={success}
+        error={true}
+        errorMessage={""}
+        outboundAnnotations={annotationsObject}
+      />
+    );
+
+    const errorHeader = getByTestId("generic-error-text-header");
+    const errorSubHeader = queryByTestId("generic-error-text-sub-header");
+    const errorList = queryByTestId("generic-error-text-list");
+
+    expect(errorHeader.textContent).toBe("Errors were found within the CQL");
+    expect(errorSubHeader?.textContent).toBe(
+      `${annotationsObject.length} CQL errors found:`
+    );
+    expect(errorList).toBeInTheDocument();
+  });
+
+  test("It displays an error message with provided error message and no annotations", () => {
+    const success = {
+      status: undefined,
+      message: "",
+    };
+    const errorMessage = "CQL problem please help";
+    render(
+      <StatusHandler
+        success={success}
+        error={true}
+        errorMessage={errorMessage}
+        outboundAnnotations={[]}
+      />
+    );
+
+    const errorHeader = getByTestId("generic-error-text-header");
+    const errorSubHeader = queryByTestId("generic-error-text-sub-header");
+    const errorList = queryByTestId("generic-error-text-list");
+
+    expect(errorHeader.textContent).toBe(errorMessage);
+    expect(errorSubHeader).not.toBeInTheDocument();
+    expect(errorList).not.toBeInTheDocument();
+  });
+
+  test("It displays an error message with error message = to error Message provided and annotations provided", () => {
+    const success = {
+      status: undefined,
+      message: "",
+    };
+    const errorMessage = "CQL problem please help";
+    render(
+      <StatusHandler
+        success={success}
+        error={true}
+        errorMessage={errorMessage}
+        outboundAnnotations={annotationsObject}
+      />
+    );
+
+    const errorHeader = getByTestId("generic-error-text-header");
+    const errorSubHeader = queryByTestId("generic-error-text-sub-header");
+    const errorList = queryByTestId("generic-error-text-list");
+
+    expect(errorHeader.textContent).toBe(errorMessage);
+    expect(errorSubHeader?.textContent).toBe(
+      `${annotationsObject.length} CQL errors found:`
+    );
+    expect(errorList).toBeInTheDocument();
+  });
+
+  test("Error flag is false, but outbound annotations exist", () => {
+    const success = {
+      status: undefined,
+      message: "",
+    };
+    render(
+      <StatusHandler
+        success={success}
+        error={false}
+        errorMessage=""
+        outboundAnnotations={annotationsObject}
+      />
+    );
+
+    const errorHeader = getByTestId("generic-error-text-header");
+    const errorSubHeader = queryByTestId("generic-error-text-sub-header");
+    const errorList = queryByTestId("generic-error-text-list");
+
+    expect(errorHeader.textContent).toBe("Errors were found within the CQL");
+    expect(errorSubHeader?.textContent).toBe(
+      `${annotationsObject.length} CQL errors found:`
+    );
+    expect(errorList).toBeInTheDocument();
+  });
+});

--- a/src/components/editCqlLibrary/statusHandler/StatusHandler.tsx
+++ b/src/components/editCqlLibrary/statusHandler/StatusHandler.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import { MadieAlert } from "@madie/madie-design-system/dist/react";
+import "./StatusHandler.scss";
+
+const StatusHandler = ({
+  success,
+  error,
+  errorMessage,
+  outboundAnnotations,
+}) => {
+  // success.status = fulfilled && elmTranslation errors
+  const transformAnnotation = (annotation) => {
+    return `Row: ${annotation.row + 1}, Col:${annotation.column}: ${
+      annotation.text
+    }`;
+  };
+  const isLength = (val) => {
+    return val.length > 0 ? "s" : "";
+  };
+  {
+    if (success.status === "success") {
+      if (outboundAnnotations && outboundAnnotations.length > 0) {
+        const mappedMessages = outboundAnnotations.map((el) => (
+          <li>{transformAnnotation(el)}</li>
+        ));
+        return (
+          <MadieAlert
+            type="success"
+            content={
+              <div aria-live="polite">
+                <h3 data-testid="generic-success-text-header">
+                  Changes saved successfully but the following errors were found
+                </h3>
+                {success.message ===
+                  "CQL updated successfully! Library Name and/or Version can not be updated in the CQL Editor. MADiE has overwritten the updated Library Name and/or Version." && (
+                  <p className="secondary" data-testid="library-warning">
+                    {success.message}
+                  </p>
+                )}
+                <h4 data-testid="generic-success-text-sub-header">{`${
+                  outboundAnnotations.length
+                } CQL error${isLength(outboundAnnotations)} found:`}</h4>
+                <ul data-testid="generic-success-text-list">
+                  {mappedMessages}
+                </ul>
+              </div>
+            }
+            canClose={false}
+          />
+        );
+      } else {
+        return (
+          <MadieAlert
+            type="success"
+            content={
+              <h3 aria-live="polite" data-testid="generic-success-text-header">
+                {success.message}
+              </h3>
+            }
+            canClose={false}
+          />
+        );
+      }
+    }
+  }
+
+  {
+    // if there's ANY error flag
+    if (error) {
+      if (errorMessage) {
+        if (outboundAnnotations && outboundAnnotations.length > 0) {
+          const mappedMessages = outboundAnnotations.map((el) => (
+            <li>{transformAnnotation(el)}</li>
+          ));
+          return (
+            <MadieAlert
+              type="error"
+              content={
+                <div aria-live="polite">
+                  <h3 data-testid="generic-error-text-header">
+                    {errorMessage}
+                  </h3>
+                  <h4 data-testid="generic-error-text-sub-header">{`${
+                    outboundAnnotations.length
+                  } CQL error${isLength(outboundAnnotations)} found:`}</h4>
+                  <ul data-testid="generic-error-text-list">
+                    {mappedMessages}
+                  </ul>
+                </div>
+              }
+              canClose={false}
+            />
+          );
+        } else {
+          return (
+            <MadieAlert
+              type="error"
+              content={
+                <h3 aria-live="polite" data-testid="generic-error-text-header">
+                  {errorMessage}
+                </h3>
+              }
+              canClose={false}
+            />
+          );
+        }
+      }
+      // if we have errors but no error message tied to it
+      if (outboundAnnotations && outboundAnnotations.length > 0) {
+        const mappedMessages = outboundAnnotations.map((el) => (
+          <li>{transformAnnotation(el)}</li>
+        ));
+        return (
+          <MadieAlert
+            type="error"
+            content={
+              <div aria-live="polite">
+                <h3 data-testid="generic-error-text-header">
+                  Errors were found within the CQL
+                </h3>
+                <h4 data-testid="generic-error-text-sub-header">{`${
+                  outboundAnnotations.length
+                } CQL error${isLength(outboundAnnotations)} found:`}</h4>
+                <ul data-testid="generic-error-text-list">{mappedMessages}</ul>
+              </div>
+            }
+            canClose={false}
+          />
+        );
+      }
+      //   if error flag is true but no information is supplied and no annotations provided
+      return (
+        <MadieAlert
+          type="error"
+          content={
+            <>
+              <h3 aria-live="polite" data-testid="generic-error-text-header">
+                Errors were found within the CQL
+              </h3>
+            </>
+          }
+          canClose={false}
+        />
+      );
+    }
+    // if the error flag is not true, but we still have errors within the cql
+    else {
+      if (outboundAnnotations.length > 0) {
+        const mappedMessages = outboundAnnotations.map((el) => (
+          <li>{transformAnnotation(el)}</li>
+        ));
+        return (
+          <MadieAlert
+            type="error"
+            content={
+              <div aria-live="polite">
+                <h3 data-testid="generic-error-text-header">
+                  Errors were found within the CQL
+                </h3>
+                <h4 data-testid="generic-error-text-sub-header">{`${
+                  outboundAnnotations.length
+                } CQL error${isLength(outboundAnnotations)} found:`}</h4>
+                <ul data-testid="generic-error-text-list">{mappedMessages}</ul>
+              </div>
+            }
+            canClose={false}
+          />
+        );
+      }
+      return <div />;
+    }
+  }
+};
+
+export default StatusHandler;

--- a/src/types/madie-madie-editor.d.ts
+++ b/src/types/madie-madie-editor.d.ts
@@ -81,6 +81,7 @@ declare module "@madie/madie-editor" {
     inboundAnnotations?: EditorAnnotation[];
     height?: string;
     readOnly?: boolean;
+    setOutboundAnnotations?: Function;
   }>;
   export const bootstrap: LifeCycleFn<void>;
   export const mount: LifeCycleFn<void>;


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4820](https://jira.cms.gov/browse/MAT-4820)
(Optional) Related Tickets:

### Summary

- CreateNewLibrary a separate component is created, removing unnecessary CreateNewLibrary functionality from EditCqlLibrary.
- Updated info alert for versioned libraries to match the designs.
<img width="498" alt="image" src="https://user-images.githubusercontent.com/57495404/199290614-5c8c5c19-73ee-4fec-810c-e3cf4b076e2c.png">

- Added alerts to the top of Editor, similar to measure cql editor.
<img width="1527" alt="image" src="https://user-images.githubusercontent.com/57495404/199290847-b9be3a3f-9600-4b0f-ad98-0801cf968336.png">

- Updated the overall layout styling to match all other pages in MADiE.
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/57495404/199291114-ba0af4ca-c867-498d-a986-d4645e62939d.png">



### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
