### PR TITLE
MAT-4971: Add onClose logic for triggering formik's on blur

### DIFF
--- a/src/components/common/CreateNewLibraryDialog.tsx
+++ b/src/components/common/CreateNewLibraryDialog.tsx
@@ -203,6 +203,9 @@ const CreateNewLibraryDialog: React.FC<TestProps> = ({
               error={formik.touched.model && Boolean(formik.errors.model)}
               helperText={formik.touched.model && formik.errors.model}
               size="small"
+              onClose={() => {
+                setFieldTouched("model");
+              }}
               options={Object.keys(Model).map((modelKey) => {
                 return (
                   <MenuItem
@@ -268,6 +271,9 @@ const CreateNewLibraryDialog: React.FC<TestProps> = ({
                 onBlur={(e) => {
                   // This really shouldn't be necessary, but formik.handleBlur
                   // isn't being triggered here.
+                  setFieldTouched("publisher");
+                }}
+                onClose={() => {
                   setFieldTouched("publisher");
                 }}
                 renderInput={(params) => (


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-4971](https://jira.cms.gov/browse/MAT-4971)
(Optional) Related Tickets:

### Summary
closing these select fields now trigger the field to be touched

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
