### PR TITLE
MAT-6089: force jaws to read required.

### DIFF
--- a/src/components/common/CreateNewLibraryDialog.test.tsx
+++ b/src/components/common/CreateNewLibraryDialog.test.tsx
@@ -217,7 +217,7 @@ describe("Library Dialog", () => {
     await waitFor(() => expect(libraryName.value).toEqual("QdmLibrary1"));
 
     const libraryDescription = screen.getByRole("textbox", {
-      name: "Description",
+      name: "Description required",
     }) as HTMLInputElement;
     userEvent.type(libraryDescription, "QDM Library Description");
     await waitFor(() =>

--- a/src/components/common/TextArea.tsx
+++ b/src/components/common/TextArea.tsx
@@ -63,6 +63,7 @@ const TextArea = ({
         disabled={disabled}
         id={id}
         inputProps={{
+          "aria-label": `${label} ${required ? "required" : ""}`,
           "data-testid": id,
           "aria-described-by": `${id}-helper-text`,
           "aria-required": required ? "true" : "false",

--- a/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
+++ b/src/components/editCqlLibrary/EditCqlLibrary.test.tsx
@@ -764,7 +764,7 @@ describe("Edit Cql Library Component", () => {
       screen.getByTestId("cql-library-name-text-field-input")
     ).toHaveAttribute("disabled");
     expect(
-      screen.getByRole("textbox", { name: "Description" })
+      screen.getByRole("textbox", { name: "Description required" })
     ).toHaveAttribute("disabled");
     expect(screen.getByRole("combobox", { name: "Publisher" })).toBeDisabled();
     expect(
@@ -823,7 +823,7 @@ describe("Edit Cql Library Component", () => {
       screen.getByTestId("cql-library-name-text-field-input")
     ).toHaveAttribute("disabled");
     expect(
-      screen.getByRole("textbox", { name: "Description" })
+      screen.getByRole("textbox", { name: "Description required" })
     ).toHaveAttribute("disabled");
     expect(screen.getByRole("combobox", { name: "Publisher" })).toBeDisabled();
 


### PR DESCRIPTION
## MADiE PR

Jira Ticket: [MAT-6089](https://jira.cms.gov/browse/MAT-6089)
(Optional) Related Tickets:

### Summary
https://github.com/FreedomScientific/standards-support/issues/553
Jaws chooses not to read valid html elements for text areas. 
there is no way to read a required value for text area normally using expected attributes.

This PR forces JAWS to read the field as required.

### All Submissions
* [x] This PR has the JIRA linked.
* [x] Required tests are included
* [x] No extemporaneous files are included (i.e Complied files or testing results)
* [x] This PR is in to the **correct branch**.
* [x] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [x] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
