### PR TITLE
MAT-7829: 1st selection of Model triggers validation when selection is valid

### DIFF
--- a/src/components/common/CreateNewLibraryDialog.tsx
+++ b/src/components/common/CreateNewLibraryDialog.tsx
@@ -243,9 +243,6 @@ const CreateNewLibraryDialog: React.FC<TestProps> = ({
               error={formik.touched.model && Boolean(formik.errors.model)}
               helperText={formik.touched.model && formik.errors.model}
               size="small"
-              onClose={() => {
-                setFieldTouched("model");
-              }}
               options={modelOptions.map((modelKey) => {
                 return (
                   <MenuItem


### PR DESCRIPTION
If a user selects a Model from the dropdown, do not show 'A CQL library model is required.' validation message. Only show validation message if the user clicks into dropdown, then clicks out of dropdown without select a dropdown value

## MADiE PR

Jira Ticket: [MAT-7829](https://jira.cms.gov/browse/MAT-7829)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
