### PR TITLE
MAT-8957 Disabling delete icon if the library is locked by a differen…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@babel/preset-typescript": "^7.14.5",
         "@babel/runtime": "^7.14.6",
         "@madie/madie-design-system": "^1.2.76",
-        "@madie/madie-models": "^1.4.42",
+        "@madie/madie-models": "^1.4.45",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^12.0.0",
         "@testing-library/user-event": "^13.5.0",
@@ -4098,9 +4098,9 @@
       }
     },
     "node_modules/@madie/madie-models": {
-      "version": "1.4.42",
-      "resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.4.42.tgz",
-      "integrity": "sha512-C2kLGaOqneAm0rvK+JRoSy0CNJkGg+N4XZNIiiE65xy8dGcaI4NNkhyin4GZZGPK5xbRfstORf9V3UokKi4/EA==",
+      "version": "1.4.45",
+      "resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.4.45.tgz",
+      "integrity": "sha512-r1+IE6j61fo9chYLZK5uj6AFawas6sUQ6GWajfpfCAO/RorDD1Cg399g2n9L/JepHMBk33y4LjIeSjfh4UL6pQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/preset-typescript": "^7.14.5",
     "@babel/runtime": "^7.14.6",
     "@madie/madie-design-system": "^1.2.76",
-    "@madie/madie-models": "^1.4.42",
+    "@madie/madie-models": "^1.4.45",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/cqlLibraryLanding/CqlLibraryLanding.test.tsx
+++ b/src/components/cqlLibraryLanding/CqlLibraryLanding.test.tsx
@@ -1,17 +1,10 @@
-import "@testing-library/jest-dom";
 // NOTE: jest-dom adds handy assertions to Jest and is recommended, but not required
 import * as React from "react";
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  within,
-} from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { CqlLibraryServiceApi } from "../../api/useCqlLibraryServiceApi";
 import { ApiContextProvider, ServiceConfig } from "../../api/ServiceContext";
-import userEvent from "@testing-library/user-event";
 import { Model, OwnershipType } from "@madie/madie-models";
+import userEvent from "@testing-library/user-event";
 // @ts-ignore
 import { useFeatureFlags } from "@madie/madie-util";
 import {

--- a/src/components/cqlLibraryLanding/CqlLibraryLanding.tsx
+++ b/src/components/cqlLibraryLanding/CqlLibraryLanding.tsx
@@ -419,7 +419,7 @@ function CqlLibraryLanding() {
           />
           <div tw="col-start-4 justify-self-end p-3">
             <ActionCenter
-              libraries={selectedLibraries}
+              selectedLibraries={selectedLibraries}
               setDeleteDraftDialog={setDeleteDraftDialog}
               setSelectedCqlLibrary={setSelectedCqlLibrary}
               setCreateDraftDialog={setCreateDraftDialog}
@@ -464,14 +464,9 @@ function CqlLibraryLanding() {
                 handleSort={handleSort}
                 handlePageChange={handlePageChange}
                 searchCriteria={searchCriteria}
-                // Toast props
-                toastOpen={toastOpen}
-                toastMessage={toastMessage}
-                toastType={toastType}
                 setToastOpen={setToastOpen}
                 setToastMessage={setToastMessage}
                 setToastType={setToastType}
-                onToastClose={onToastClose}
               />
             )}
           </div>

--- a/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/CqlLibraryListActionCenter.tsx
+++ b/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/CqlLibraryListActionCenter.tsx
@@ -6,7 +6,6 @@ import ShareAction from "./shareAction/ShareAction";
 import HistoryAction from "./historyAction/HistoryAction";
 import { CqlLibrary } from "@madie/madie-models";
 import {
-  checkUserCanDelete,
   checkUserCanEdit,
   useFeatureFlags,
   useOktaTokens,
@@ -14,7 +13,7 @@ import {
 import TransferAction from "./transferAction/TransferAction";
 
 interface PropTypes {
-  libraries: CqlLibrary[];
+  selectedLibraries: CqlLibrary[];
   setDeleteDraftDialog: (value: any) => void;
   setSelectedCqlLibrary: (value: any) => void;
   setCreateDraftDialog: (value: any) => void;
@@ -27,9 +26,8 @@ interface PropTypes {
 
 export function CqlLibraryListActionCenter(props: PropTypes) {
   const {
-    libraries,
+    selectedLibraries,
     setDeleteDraftDialog,
-    setSelectedCqlLibrary,
     setCreateDraftDialog,
     createVersion,
     owners,
@@ -37,26 +35,23 @@ export function CqlLibraryListActionCenter(props: PropTypes) {
   const featureFlags = useFeatureFlags();
   const { getUserName } = useOktaTokens();
   const userName = getUserName();
-  const canEdit = libraries
+  const canEdit = selectedLibraries
     ? checkUserCanEdit(
-        libraries[0]?.librarySet?.owner,
-        libraries[0]?.librarySet?.acls
+        selectedLibraries[0]?.librarySet?.owner,
+        selectedLibraries[0]?.librarySet?.acls
       )
-    : false;
-  const canDelete = libraries
-    ? checkUserCanDelete(libraries[0]?.librarySet?.owner, libraries[0]?.draft)
     : false;
 
   function deleteLibrary() {
     setDeleteDraftDialog({
       open: true,
-      cqlLibrary: libraries[0],
+      cqlLibrary: selectedLibraries[0],
     });
   }
   function createDraft() {
     setCreateDraftDialog({
       open: true,
-      cqlLibrary: libraries[0],
+      cqlLibrary: selectedLibraries[0],
     });
   }
 
@@ -67,40 +62,38 @@ export function CqlLibraryListActionCenter(props: PropTypes) {
         option,
       });
     },
-    [props.setShareDialog]
+    [props]
   );
 
   const transferLibrary = useCallback(() => {
-    if (props.libraries?.length > 0) {
+    if (selectedLibraries?.length > 0) {
       props.setTransferDialog({ open: true });
     }
-  }, [props.libraries, props.setTransferDialog]);
+  }, [selectedLibraries?.length, props]);
 
   return (
     <div data-testid="action-center">
       <DeleteAction
-        libraries={libraries}
-        canEdit={canEdit}
-        canDelete={canDelete}
         onClick={deleteLibrary}
+        selectedLibraries={selectedLibraries}
       />
 
       <VersionAction
-        libraries={libraries}
+        libraries={selectedLibraries}
         canEdit={canEdit}
         onClick={createVersion}
       />
 
       <DraftAction
-        libraries={libraries}
+        libraries={selectedLibraries}
         canEdit={canEdit}
         onClick={createDraft}
       />
       {featureFlags?.LibraryHistory && (
-        <HistoryAction libraries={libraries} onClick={() => {}} />
+        <HistoryAction libraries={selectedLibraries} onClick={() => {}} />
       )}
       <ShareAction
-        libraries={libraries}
+        libraries={selectedLibraries}
         canEdit={canEdit}
         onClick={shareLibrary}
         userName={userName}
@@ -108,7 +101,7 @@ export function CqlLibraryListActionCenter(props: PropTypes) {
       />
       {featureFlags?.TransferLibrary && (
         <TransferAction
-          libraries={libraries}
+          libraries={selectedLibraries}
           onClick={transferLibrary}
           activeTab={props?.activeTab}
         />

--- a/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.test.tsx
+++ b/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.test.tsx
@@ -1,34 +1,34 @@
 import * as React from "react";
 import { render, screen } from "@testing-library/react";
-import DeleteAction, { DEL_LIBRARY, NOTHING_SELECTED } from "./DeleteAction";
-import { CqlLibrary, Model } from "@madie/madie-models";
+import DeleteAction, {
+  DEL_LIBRARY,
+  NOTHING_SELECTED,
+  LOCKED_LIBRARY_PREFIX,
+  PERMISSION_DENIED,
+} from "./DeleteAction";
+import { CqlLibrary } from "@madie/madie-models";
 
-const mockUser = "test user";
+// mock for permission utility
+const mockCheckUserCanDelete = jest.fn();
 jest.mock("@madie/madie-util", () => ({
-  useOktaTokens: () => ({
-    getUserName: () => mockUser,
-  }),
+  checkUserCanDelete: (...args: any[]) => mockCheckUserCanDelete(...args),
 }));
 
-const library = {
-  id: "67180dd54665c8239413ba90",
+const baseLibrary = {
+  id: "lib-1",
   cqlLibraryName: "TestLib",
-  createdAt: "2024-10-22T20:40:53.212Z",
-  model: "QI-Core v4.1.1",
-  version: "0.0.000",
   draft: true,
-} as CqlLibrary;
+  librarySet: { owner: "ownerUser" },
+} as unknown as CqlLibrary;
 
-describe("DeleteAction", () => {
+describe("DeleteAction (CQL Library)", () => {
+  beforeEach(() => {
+    mockCheckUserCanDelete.mockReset();
+  });
+
   it("Should disable action btn if no library selected", () => {
-    render(
-      <DeleteAction
-        libraries={[]}
-        canDelete={true}
-        onClick={() => {}}
-        canEdit={true}
-      />
-    );
+    mockCheckUserCanDelete.mockReturnValue(false); // irrelevant
+    render(<DeleteAction selectedLibraries={[]} onClick={() => {}} />);
     expect(screen.getByTestId("delete-action-btn")).toBeDisabled();
     expect(screen.getByTestId("delete-action-tooltip")).toHaveAttribute(
       "aria-label",
@@ -36,14 +36,38 @@ describe("DeleteAction", () => {
     );
   });
 
-  it("Should enable action btn if user select one library ", () => {
+  it("Should show permission denied when one selected and no permission", () => {
+    mockCheckUserCanDelete.mockReturnValue(false);
     render(
-      <DeleteAction
-        canDelete={true}
-        libraries={[library]}
-        onClick={() => {}}
-        canEdit={true}
-      />
+      <DeleteAction selectedLibraries={[baseLibrary]} onClick={() => {}} />
+    );
+    expect(screen.getByTestId("delete-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("delete-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      PERMISSION_DENIED
+    );
+  });
+
+  it("Should show locked message when one selected, has permission, but locked", () => {
+    const lockedLibrary = {
+      ...baseLibrary,
+      cqlLibraryLock: { lockedBy: "HARP123" },
+    } as CqlLibrary;
+    mockCheckUserCanDelete.mockReturnValue(true);
+    render(
+      <DeleteAction selectedLibraries={[lockedLibrary]} onClick={() => {}} />
+    );
+    expect(screen.getByTestId("delete-action-btn")).toBeDisabled();
+    expect(screen.getByTestId("delete-action-tooltip")).toHaveAttribute(
+      "aria-label",
+      `${LOCKED_LIBRARY_PREFIX}HARP123`
+    );
+  });
+
+  it("Should enable action btn if one library selected, has permission, and not locked", () => {
+    mockCheckUserCanDelete.mockReturnValue(true);
+    render(
+      <DeleteAction selectedLibraries={[baseLibrary]} onClick={() => {}} />
     );
     expect(screen.getByTestId("delete-action-btn")).not.toBeDisabled();
     expect(screen.getByTestId("delete-action-tooltip")).toHaveAttribute(
@@ -51,13 +75,14 @@ describe("DeleteAction", () => {
       DEL_LIBRARY
     );
   });
-  it("Should disable action btn if user cannot edit ", () => {
+
+  it("Should disable btn and show NOTHING_SELECTED if multiple libraries selected", () => {
+    mockCheckUserCanDelete.mockReturnValue(true); // even with permission, multiple selection overrides
+    const anotherLibrary = { ...baseLibrary, id: "lib-2" } as CqlLibrary;
     render(
       <DeleteAction
-        canDelete={false}
-        libraries={[library]}
+        selectedLibraries={[baseLibrary, anotherLibrary]}
         onClick={() => {}}
-        canEdit={false}
       />
     );
     expect(screen.getByTestId("delete-action-btn")).toBeDisabled();
@@ -67,20 +92,19 @@ describe("DeleteAction", () => {
     );
   });
 
-  it("Should disable btn if user selects two libraries", () => {
-    const library2 = library;
+  it("Should show permission denied instead of locked when both conditions present (precedence test)", () => {
+    const lockedLibrary = {
+      ...baseLibrary,
+      cqlLibraryLock: { lockedBy: "HARP999" },
+    } as CqlLibrary;
+    mockCheckUserCanDelete.mockReturnValue(false); // no permission
     render(
-      <DeleteAction
-        canDelete={true}
-        libraries={[library, library2]}
-        onClick={() => {}}
-        canEdit={true}
-      />
+      <DeleteAction selectedLibraries={[lockedLibrary]} onClick={() => {}} />
     );
     expect(screen.getByTestId("delete-action-btn")).toBeDisabled();
     expect(screen.getByTestId("delete-action-tooltip")).toHaveAttribute(
       "aria-label",
-      NOTHING_SELECTED
+      PERMISSION_DENIED
     );
   });
 });

--- a/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.tsx
+++ b/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.tsx
@@ -3,10 +3,11 @@ import { IconButton } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
 import { checkUserCanDelete } from "@madie/madie-util";
+import { CqlLibrary } from "@madie/madie-models";
 
 interface PropTypes {
   onClick: () => void;
-  selectedLibraries?: any;
+  selectedLibraries?: CqlLibrary[];
 }
 
 export const NOTHING_SELECTED = "Select library to delete";

--- a/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.tsx
+++ b/src/components/cqlLibraryLanding/cqlLibraryListActionCenter/deleteAction/DeleteAction.tsx
@@ -1,42 +1,63 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React from "react";
 import { IconButton } from "@mui/material";
 import Tooltip from "@mui/material/Tooltip";
-import { CqlLibrary } from "@madie/madie-models";
 import DeleteOutlinedIcon from "@mui/icons-material/DeleteOutlined";
+import { checkUserCanDelete } from "@madie/madie-util";
 
 interface PropTypes {
-  libraries: CqlLibrary[];
   onClick: () => void;
-  canEdit: boolean;
-  canDelete: boolean;
+  selectedLibraries?: any;
 }
 
 export const NOTHING_SELECTED = "Select library to delete";
 export const DEL_LIBRARY = "Delete library";
+export const LOCKED_LIBRARY_PREFIX =
+  "Unable to delete library.  Locked while being edited by ";
+export const PERMISSION_DENIED =
+  "You do not have permissions to delete this library";
 
 export default function DeleteAction(props: PropTypes) {
-  const { libraries, canEdit, canDelete } = props;
-  const [disableDeleteBtn, setDisableDeleteBtn] = useState(true);
-  const [tooltipMessage, setTooltipMessage] = useState(NOTHING_SELECTED);
-  const validateDeleteActionState = useCallback(() => {
-    setDisableDeleteBtn(true);
-    setTooltipMessage(NOTHING_SELECTED);
-    if (libraries?.length === 1 && canDelete) {
-      setDisableDeleteBtn(false);
-      setTooltipMessage(DEL_LIBRARY);
-    }
-  }, [libraries, canEdit]);
+  const { selectedLibraries } = props;
 
-  useEffect(() => {
-    validateDeleteActionState();
-  }, [libraries, validateDeleteActionState]);
+  const exactlyOneSelected = selectedLibraries?.length === 1;
+  const selectedLibrary = exactlyOneSelected
+    ? selectedLibraries?.[0]
+    : undefined;
+  const lockedBy = selectedLibrary?.cqlLibraryLock?.lockedBy;
+  const isLocked = !!lockedBy;
+  const hasPermission =
+    !!selectedLibrary &&
+    checkUserCanDelete(
+      selectedLibrary?.librarySet?.owner,
+      selectedLibrary?.draft
+    );
+  const canDelete =
+    !!selectedLibrary && exactlyOneSelected && hasPermission && !isLocked;
+
+  // tooltip precedence:
+  // 1. Nothing selected (none or multiple)
+  // 2. Permission denied (one selected, not locked, lacks permission)
+  // 3. Locked (one selected, has permission, locked)
+  // 4. Deletable
+  let tooltipMessage = NOTHING_SELECTED;
+  if (exactlyOneSelected) {
+    if (!hasPermission) {
+      tooltipMessage = PERMISSION_DENIED;
+    } else if (isLocked) {
+      tooltipMessage = `${LOCKED_LIBRARY_PREFIX}${lockedBy}`;
+    } else if (canDelete) {
+      tooltipMessage = DEL_LIBRARY;
+    }
+  }
+
+  const disabled = !canDelete;
 
   return (
     <Tooltip data-testid="delete-action-tooltip" title={tooltipMessage} arrow>
       <span>
         <IconButton
           onClick={() => props.onClick()}
-          disabled={disableDeleteBtn}
+          disabled={disabled}
           data-testid="delete-action-btn"
           className="DeleteClass"
         >

--- a/src/components/cqlLibraryList/CqlLibraryList.test.tsx
+++ b/src/components/cqlLibraryList/CqlLibraryList.test.tsx
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import useCqlLibraryServiceApi, {
   CqlLibraryServiceApi,
 } from "../../api/useCqlLibraryServiceApi";
+// @ts-ignore
 import { checkUserCanEdit, useFeatureFlags } from "@madie/madie-util";
 
 jest.mock("@madie/madie-util", () => ({
@@ -145,8 +146,13 @@ describe("CqlLibrary List component", () => {
         offset={0}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
     cqlLibrary.forEach((c) => {
@@ -227,8 +233,13 @@ describe("CqlLibrary List component", () => {
         offset={0}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 
@@ -283,8 +294,13 @@ describe("CqlLibrary List component", () => {
         offset={0}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 
@@ -297,6 +313,7 @@ describe("CqlLibrary List component", () => {
       screen.queryByRole("button", { name: "View/Edit" })
     ).not.toBeInTheDocument();
   });
+
   it("buttons featureflag: shows just an edit button when can edit", async () => {
     (checkUserCanEdit as jest.Mock).mockReturnValue(true);
     const cqlLibrary: CqlLibrary[] = [
@@ -343,8 +360,13 @@ describe("CqlLibrary List component", () => {
         offset={0}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
     expect(
@@ -423,13 +445,18 @@ describe("CqlLibrary List component", () => {
         setOwners={jest.fn()}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         totalItems={10}
         activeTab={1}
         totalPages={20}
         visibleItems={10}
         offset={0}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 
@@ -504,13 +531,18 @@ describe("CqlLibrary List component", () => {
         setOwners={jest.fn()}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         totalItems={10}
         activeTab={0}
         totalPages={20}
         visibleItems={10}
         offset={0}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 
@@ -581,13 +613,18 @@ describe("CqlLibrary List component", () => {
         setOwners={jest.fn()}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         totalItems={10}
         activeTab={1}
         totalPages={20}
         visibleItems={10}
         offset={0}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 
@@ -658,13 +695,18 @@ describe("CqlLibrary List component", () => {
         setOwners={jest.fn()}
         sorting={[{ id: "cqlLibraryName", desc: false }]}
         handleSort={jest.fn()}
+        handlePageChange={jest.fn()}
         totalItems={10}
         activeTab={2}
         totalPages={20}
         visibleItems={10}
         offset={0}
         curLimit={10}
+        curPage={1}
         searchCriteria={mockSearchCriteria}
+        setToastOpen={jest.fn()}
+        setToastMessage={jest.fn()}
+        setToastType={jest.fn()}
       />
     );
 

--- a/src/components/cqlLibraryList/CqlLibraryList.tsx
+++ b/src/components/cqlLibraryList/CqlLibraryList.tsx
@@ -24,7 +24,6 @@ import useCqlLibraryServiceApi from "../../api/useCqlLibraryServiceApi";
 import CreateDraftDialog from "../createDraftDialog/CreateDraftDialog";
 import Snackbar from "@mui/material/Snackbar";
 import MuiAlert, { AlertProps } from "@mui/material/Alert";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   checkUserCanDelete,
   checkUserCanEdit,
@@ -142,14 +141,9 @@ export default function CqlLibraryList({
   curLimit,
   curPage,
   searchCriteria,
-  // Toast props
-  toastOpen,
-  toastMessage,
-  toastType,
   setToastOpen,
   setToastMessage,
   setToastType,
-  onToastClose,
 }) {
   const [selectedIdForExpansion, setSelectedIdForExpansion] = useState(null);
   const [isRowExpanded, setIsRowExpanded] = useState<boolean>(false);


### PR DESCRIPTION
…t user

## MADiE PR

Jira Ticket: [MAT-8957](https://jira.cms.gov/browse/MAT-8957)
(Optional) Related Tickets:

### Summary

1. Updated delete button to be disabled if the user doesn't have permissions or if the library is locked by a different user.
2. The tool tips reflect the cause for the icon to be disabled.
3. if the delete icon is enabled due to stale data, then the backend API will reject the delete request - if the library is locked by a different user.

<img width="1649" height="1164" alt="image" src="https://github.com/user-attachments/assets/f9db6b3e-3dbc-4817-aca6-55b82570e251" />

<img width="1621" height="616" alt="image" src="https://github.com/user-attachments/assets/cbe28436-4f33-4b1e-b467-6decebd65de9" />

<img width="1628" height="624" alt="image" src="https://github.com/user-attachments/assets/cb083130-d391-4bd7-8b52-f2724bb91560" />


### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
