### PR TITLE
MAT-9527: make the top part of the screen (header, measure name, and …

### DIFF
--- a/src/components/common/compareVersionsDialog/CompareVersionsDialog.scss
+++ b/src/components/common/compareVersionsDialog/CompareVersionsDialog.scss
@@ -21,6 +21,11 @@
   border-color: #8c8c8c;
 }
 
+.cql-diff-viewer {
+  max-height: calc(100vh - 500px);
+  overflow-y: auto;
+}
+
 .cql-comparison-panels-container {
   display: flex;
 

--- a/src/components/common/compareVersionsDialog/CompareVersionsDialog.tsx
+++ b/src/components/common/compareVersionsDialog/CompareVersionsDialog.tsx
@@ -106,7 +106,9 @@ const CompareVersionsDialog = ({
             <LibraryComparisonPanel library={newLibrary} side="new" />
           </div>
 
-          <CqlDiffViewer oldLibrary={oldLibrary} newLibrary={newLibrary} />
+          <div className="cql-diff-viewer">
+            <CqlDiffViewer oldLibrary={oldLibrary} newLibrary={newLibrary} />
+          </div>
         </>
       )}
     </MadieDialog>


### PR DESCRIPTION
…CQL/Human Readable tabs) sticky while the remainder of the screen scrolls

<img width="2544" height="1285" alt="image" src="https://github.com/user-attachments/assets/5b6d6e05-dddb-4829-8ac2-a4c923e2a834" />

## MADiE PR

Jira Ticket: [MAT-9527](https://jira.cms.gov/browse/MAT-9527)
(Optional) Related Tickets:

### Summary

### All Submissions
* [ ] This PR has the JIRA linked.
* [ ] Required tests are included
* [ ] No extemporaneous files are included (i.e Complied files or testing results)
* [ ] This PR is in to the **correct branch**.
* [ ] All Documentation as needed for this PR is Complete (or noted in a TODO or other Ticket)
* [ ] Any breaking changes or failing automation are noted by placing a comment on this PR.

### DevSecOps
If there is a question if this PR has a security or infrastructure impact, please contact the Security or DevOps engineer assigned to this project to discuss it further.

* [ ] This PR has NO significant security impact (i.e Changing auth methods, Adding a new user type, Adding a required but vulnerable package)
* [ ] All CDN/Web dependancies are hosted internally (i.e MADiE-Root Repo)

### Reviewers
By Approving this PR you are attesting to the following:

*  Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
*  The tests appropriately test the new code, including edge cases
*  If you have any concerns they are brought up either to the developer assigned, security engineer, or leads
